### PR TITLE
fix: delay for flow subscription

### DIFF
--- a/booksamples/src/main/java/com/peterlaurence/book/pawk/flows/sharedflow/eventbus/eventbus.kt
+++ b/booksamples/src/main/java/com/peterlaurence/book/pawk/flows/sharedflow/eventbus/eventbus.kt
@@ -40,9 +40,9 @@ class Downloader(private val eventBus: EventBus, val scope: CoroutineScope) {
 fun main() = runBlocking {
     val eventBus = EventBus()
 
-    delay(100)
     println("start download")
     Downloader(eventBus, this)
+    delay(100)
     eventBus.startDownload("http://somewebsite_link")
     Unit
 }


### PR DESCRIPTION
Hi, I think this line of code `delay(100)` has been misplaced.
After the change, it can receive the `DownloadEvent` in `Downloader`.